### PR TITLE
add: dependencies to build crypto native libs OPS-6186

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM node:lts-alpine
 
-RUN apk add python3 py3-pip zip gcc \
+RUN apk add python3 py3-pip zip gcc curl make \
+  && curl https://sh.rustup.rs -sSf | sh -s -- -y \
+  && apk add gcc musl-dev python3-dev libffi-dev openssl-dev \
   && pip3 install --upgrade pip \
   && pip3 install --upgrade awscli \
   && rm -rf /var/cache/apk/*
+
+ENV PATH="/root/.cargo/bin:$PATH"
 
 RUN npm install --global serverless
 


### PR DESCRIPTION
Need to update Rust manually as the default install on Alpine is too old