### PR TITLE
mod: limit SLS to major version 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
   && pip3 install --upgrade awscli \
   && apt-get clean
 
-RUN npm install --global serverless yarn
+RUN npm install --global serverless@2.x.x yarn
 
 RUN mkdir /build
 


### PR DESCRIPTION
There are breaking changes in version 3 for which we
need to update our serverless.yml config