### PR TITLE
add: user uid and renamed to jenkins user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN npm install --global serverless@2.x.x yarn
 
 RUN mkdir /build
 
-RUN useradd -m wealthwizards
+RUN useradd -m jenkins -u 999
 
-RUN chown wealthwizards /build
+RUN chown jenkins /build
 RUN chmod u+rwx /build
 
-USER wealthwizards
+USER jenkins
 
 WORKDIR /build


### PR DESCRIPTION
Adding an explicit user id fixes permissions issues when mounting volumes to this image in the CI pipeline. Not a very nice solution but does the job for now.